### PR TITLE
feat: Implement real RiskService logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ build/
 
 ### VS Code ###
 .vscode/
+
+### .env files ###
+.env
+.env.local
+.env.*.local

--- a/src/main/java/com/threatbeacon/backend/incident/IncidentRepository.java
+++ b/src/main/java/com/threatbeacon/backend/incident/IncidentRepository.java
@@ -15,4 +15,7 @@ public interface IncidentRepository extends JpaRepository<Incident, Long> {
 
     // For the dashboard (Overview)
     List<Incident> findByStatusOrderByUpdatedAtDesc(IncidentStatus status);
+
+    // For RiskService to get all active incidents
+    List<Incident> findAllByStatus(IncidentStatus status);
 }

--- a/src/main/java/com/threatbeacon/backend/risk/RiskService.java
+++ b/src/main/java/com/threatbeacon/backend/risk/RiskService.java
@@ -1,47 +1,38 @@
 package com.threatbeacon.backend.risk;
 
 import com.threatbeacon.backend.beacon.BeaconStateService;
+import com.threatbeacon.backend.incident.Incident;
+import com.threatbeacon.backend.incident.IncidentRepository;
+import com.threatbeacon.backend.incident.IncidentSeverity;
+import com.threatbeacon.backend.incident.IncidentStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.ZonedDateTime;
+import java.util.List;
 
-/**
- * Service responsible for calculating and managing the system's risk status.
-
- * What it does:
- * - Calculates the risk level based on whether the buzzer is muted.
- * - Updates the buzzer mute state and recalculates risk.
- * - Retrieves the current risk status from the beacon state.
-
- * What it contains:
- * - A reference to BeaconStateService for reading and updating the beacon state.
- * - Logging for debugging, warnings, and operational visibility.
- * - Methods to calculate, update, and fetch risk status.
-
- * What it needs:
- * - A working implementation of BeaconStateService.
- * - The RiskLevel enum and RiskStatus model.
- * - Spring Boot dependency injection (@Service, @RequiredArgsConstructor).
- * - System clock access to generate timestamps (ZonedDateTime.now()).
- */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class RiskService {
 
     private final BeaconStateService beaconStateService;
+    private final IncidentRepository incidentRepository;
 
-//Core function used by the controller to compute risk level
-    //based solely on mute state (for now)
     public RiskStatus calculateRiskStatus(Boolean buzzerMuted) {
         if (buzzerMuted == null) {
             log.warn("Null buzzerMuted received -> fallback to NON muted state.");
             buzzerMuted = false;
         }
 
-        RiskLevel level = buzzerMuted ? RiskLevel.NORMAL : RiskLevel.SUSPICIOUS;
+        List<Incident> activeIncidents = incidentRepository.findAllByStatus(IncidentStatus.OPEN);
+        RiskLevel level = calculateRiskLevel(activeIncidents);
+
+        if (level == RiskLevel.NORMAL) {
+            beaconStateService.setBuzzerMuted(false);
+            buzzerMuted = false;
+        }
 
         log.info("Risk calculated | level: {}, buzzerMuted: {}", level, buzzerMuted);
 
@@ -52,9 +43,20 @@ public class RiskService {
         );
     }
 
-//High-level service: update mute state and recompute risk.
-    //Adaped for extensibility while maintaining controller logic...
+    private RiskLevel calculateRiskLevel(List<Incident> activeIncidents) {
+        if (activeIncidents.isEmpty()) {
+            return RiskLevel.NORMAL;
+        }
 
+        boolean hasHighOrCritical = activeIncidents.stream()
+                .anyMatch(incident -> incident.getSeverity() == IncidentSeverity.HIGH || incident.getSeverity() == IncidentSeverity.CRITICAL);
+
+        if (hasHighOrCritical) {
+            return RiskLevel.CRITICAL;
+        }
+
+        return RiskLevel.SUSPICIOUS;
+    }
 
     public RiskStatus updateMuteAndRecalculateRisk(Boolean newMutedState) {
         if (newMutedState == null) {
@@ -72,7 +74,6 @@ public class RiskService {
         return calculateRiskStatus(newMutedState);
     }
 
-//Convenience method to retrieve current state of the system risk.
     public RiskStatus getCurrentRiskStatus() {
         boolean currentMuted = beaconStateService.getBeaconState().isBuzzerMuted();
         return calculateRiskStatus(currentMuted);

--- a/src/test/java/com/threatbeacon/backend/controllertes/BeaconControllerTest.java
+++ b/src/test/java/com/threatbeacon/backend/controllertes/BeaconControllerTest.java
@@ -2,7 +2,6 @@ package com.threatbeacon.backend.controllertes;
 
 
 import com.threatbeacon.backend.MapStruct.BeaconMapper;
-import com.threatbeacon.backend.api.dto.MuteRequestDto;
 import com.threatbeacon.backend.beacon.BeaconController;
 import com.threatbeacon.backend.beacon.BeaconStateService;
 import com.threatbeacon.backend.beacon.command.MuteCommand;
@@ -11,10 +10,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -32,6 +33,7 @@ class BeaconControllerTest {
     private BeaconMapper beaconMapper;
 
     @Test
+    @WithMockUser
     void testMuteBeacon() throws Exception {
 
         MuteCommand command = new MuteCommand();
@@ -43,6 +45,7 @@ class BeaconControllerTest {
                 post("/api/beacon/mute")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"muted\": true}")
+                        .with(csrf())
         ).andExpect(status().isNoContent());
     }
 }

--- a/src/test/java/com/threatbeacon/backend/risk/RiskServiceTest.java
+++ b/src/test/java/com/threatbeacon/backend/risk/RiskServiceTest.java
@@ -1,0 +1,99 @@
+package com.threatbeacon.backend.risk;
+
+import com.threatbeacon.backend.beacon.BeaconStateService;
+import com.threatbeacon.backend.incident.Incident;
+import com.threatbeacon.backend.incident.IncidentRepository;
+import com.threatbeacon.backend.incident.IncidentSeverity;
+import com.threatbeacon.backend.incident.IncidentStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class RiskServiceTest {
+
+    @Mock
+    private IncidentRepository incidentRepository;
+
+    @Mock
+    private BeaconStateService beaconStateService;
+
+    @InjectMocks
+    private RiskService riskService;
+
+    @Test
+    void calculateRiskStatus_shouldReturnNormalAndResetMute_whenNoActiveIncidents() {
+        // Arrange: No active incidents
+        when(incidentRepository.findAllByStatus(IncidentStatus.OPEN)).thenReturn(Collections.emptyList());
+
+        // Act: Calculate risk, starting with buzzer muted
+        RiskStatus riskStatus = riskService.calculateRiskStatus(true);
+
+        // Assert
+        assertEquals(RiskLevel.NORMAL, riskStatus.getLevel());
+        assertFalse(riskStatus.isBuzzerMuted());
+        verify(beaconStateService).setBuzzerMuted(false);
+    }
+
+    @Test
+    void calculateRiskStatus_shouldReturnSuspicious_andPreserveMuteState() {
+        // Arrange: Active incidents with LOW and MEDIUM severity
+        List<Incident> incidents = List.of(
+                Incident.builder().severity(IncidentSeverity.LOW).build(),
+                Incident.builder().severity(IncidentSeverity.MEDIUM).build()
+        );
+        when(incidentRepository.findAllByStatus(IncidentStatus.OPEN)).thenReturn(incidents);
+
+        // Act: Calculate risk, starting with buzzer muted
+        RiskStatus riskStatus = riskService.calculateRiskStatus(true);
+
+        // Assert
+        assertEquals(RiskLevel.SUSPICIOUS, riskStatus.getLevel());
+        // Verify that the mute state is preserved (it should still be true)
+        assertTrue(riskStatus.isBuzzerMuted());
+        // Verify that the service was NOT called to change the mute state
+        verify(beaconStateService, never()).setBuzzerMuted(anyBoolean());
+    }
+
+    @Test
+    void calculateRiskStatus_shouldReturnCritical_whenHighIncidentExists() {
+        // Arrange: Active incidents including one with HIGH severity
+        List<Incident> incidents = List.of(
+                Incident.builder().severity(IncidentSeverity.LOW).build(),
+                Incident.builder().severity(IncidentSeverity.HIGH).build()
+        );
+        when(incidentRepository.findAllByStatus(IncidentStatus.OPEN)).thenReturn(incidents);
+
+        // Act
+        RiskStatus riskStatus = riskService.calculateRiskStatus(false);
+
+        // Assert
+        assertEquals(RiskLevel.CRITICAL, riskStatus.getLevel());
+        assertFalse(riskStatus.isBuzzerMuted());
+    }
+
+    @Test
+    void calculateRiskStatus_shouldReturnCritical_whenCriticalIncidentExists() {
+        // Arrange: Active incidents including one with CRITICAL severity
+        List<Incident> incidents = List.of(
+                Incident.builder().severity(IncidentSeverity.MEDIUM).build(),
+                Incident.builder().severity(IncidentSeverity.CRITICAL).build()
+        );
+        when(incidentRepository.findAllByStatus(IncidentStatus.OPEN)).thenReturn(incidents);
+
+        // Act
+        RiskStatus riskStatus = riskService.calculateRiskStatus(true);
+
+        // Assert
+        assertEquals(RiskLevel.CRITICAL, riskStatus.getLevel());
+        assertTrue(riskStatus.isBuzzerMuted());
+    }
+}


### PR DESCRIPTION
Closes threatbeacon-backend#<HU-number>

### What was done?

*   Implemented the business logic for `RiskService` to calculate the system's risk level based on active incidents from the database, as required by the acceptance criteria.
*   The risk level is now determined as follows:
    *   `NORMAL`: No active incidents.
    *   `SUSPICIOUS`: Only `LOW` or `MEDIUM` severity incidents are active.
    *   `CRITICAL`: At least one `HIGH` or `CRITICAL` severity incident is active.
*   Added a new method `findAllByStatus` to `IncidentRepository` to fetch active incidents.
*   Ensured that when the risk level returns to `NORMAL`, the `buzzerMuted` state is automatically reset to `false` by calling `BeaconStateService`.
*   Added comprehensive unit tests in `RiskServiceTest` to cover all logical paths and acceptance criteria.
*   Fixed a failing controller test (`BeaconControllerTest`) by adding the necessary Spring Security test configuration (`@WithMockUser` and `csrf()`) to handle authentication and CSRF protection.

### Why was it done?

This PR fulfills the acceptance criteria for User Story **T2.4.3**. The previous implementation of `RiskService` had placeholder logic. This change connects the service to real data, making the `GET /api/risk` endpoint reflect the actual state of system threats.

### How to test it?

1.  **Automated Tests:**
    *   Run all tests in `RiskServiceTest.java`. They must all pass and verify the core business logic.
    *   Run the test in `BeaconControllerTest.java`. It must also pass.

2.  **Manual API Testing:**
    *   Run the application.
    *   **Scenario 1 (NORMAL):** With no `OPEN` incidents in the database, call `GET /api/risk`. The response should show `level: "NORMAL"` and `buzzerMuted: false`.
    *   **Scenario 2 (SUSPICIOUS):** Add one or more incidents with `status: "OPEN"` and `severity: "LOW"` or `"MEDIUM"`. Call `GET /api/risk`. The response should show `level: "SUSPICIOUS"`.
    *   **Scenario 3 (CRITICAL):** Add at least one incident with `status: "OPEN"` and `severity: "HIGH"` or `"CRITICAL"`. Call `GET /api/risk`. The response should show `level: "CRITICAL"`.
    *   **Scenario 4 (Reset):** After being in a `SUSPICIOUS` or `CRITICAL` state, change the status of all incidents to `CLOSED`. Call `GET /api/risk` again. The response should return to `level: "NORMAL"` and `buzzerMuted: false`.
