### PR TITLE
feat: Configure HTTP Basic authentication for API

### DIFF
--- a/src/main/java/com/threatbeacon/backend/config/SecurityConfig.java
+++ b/src/main/java/com/threatbeacon/backend/config/SecurityConfig.java
@@ -2,12 +2,12 @@ package com.threatbeacon.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -20,25 +20,27 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-                // 1. Disable CSRF: Required for POST/PUT/DELETE requests to work in a REST API
                 .csrf(csrf -> csrf.disable())
-                // 2. Authorization settings
                 .authorizeHttpRequests(auth -> auth
-                        // Allows public access to all routes under /api/beacon (including /mute)
-                        .requestMatchers("/api/beacon/**","/api/risk").permitAll()
-                        // Any other request must be authenticated (default behavior)
-                        .anyRequest().authenticated()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().permitAll()
                 )
                 .httpBasic(withDefaults());
         return http.build();
     }
+
     @Bean
-    public UserDetailsService userDetailsService() {
-        UserDetails user = User.withUsername("soc-demo")
-                .password("{noop}demo123!") // {noop} indicates that the password is not encrypted (dev only)
+    public InMemoryUserDetailsManager userDetailsService(PasswordEncoder passwordEncoder) { // <-- Inyecta el PasswordEncoder
+        UserDetails user = User.builder()
+                .username("soc-demo")
+                .password(passwordEncoder.encode("demo123!")) // <-- Usa la instancia inyectada
                 .roles("USER")
                 .build();
-
         return new InMemoryUserDetailsManager(user);
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/src/test/java/com/threatbeacon/backend/controllertes/BeaconControllerTest.java
+++ b/src/test/java/com/threatbeacon/backend/controllertes/BeaconControllerTest.java
@@ -1,26 +1,25 @@
 package com.threatbeacon.backend.controllertes;
 
-
 import com.threatbeacon.backend.MapStruct.BeaconMapper;
 import com.threatbeacon.backend.beacon.BeaconController;
 import com.threatbeacon.backend.beacon.BeaconStateService;
 import com.threatbeacon.backend.beacon.command.MuteCommand;
+import com.threatbeacon.backend.config.SecurityConfig; // Import main security config
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.httpBasic;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BeaconController.class)
-@Import(BeaconTestConfig.class)   // Import the test configuration class
+@Import({BeaconTestConfig.class, SecurityConfig.class}) // Explicitly import SecurityConfig
 class BeaconControllerTest {
 
     @Autowired
@@ -33,19 +32,39 @@ class BeaconControllerTest {
     private BeaconMapper beaconMapper;
 
     @Test
-    @WithMockUser
-    void testMuteBeacon() throws Exception {
-
+    void testMuteBeacon_withCorrectCredentials_shouldSucceed() throws Exception {
+        // Arrange
         MuteCommand command = new MuteCommand();
         command.setMuted(true);
-
         when(beaconMapper.toMuteCommand(any())).thenReturn(command);
 
+        // Act & Assert
         mockMvc.perform(
                 post("/api/beacon/mute")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\"muted\": true}")
-                        .with(csrf())
+                        .with(httpBasic("soc-demo", "demo123!"))
         ).andExpect(status().isNoContent());
+    }
+
+    @Test
+    void testMuteBeacon_withWrongCredentials_shouldReturnUnauthorized() throws Exception {
+        // Act & Assert
+        mockMvc.perform(
+                post("/api/beacon/mute")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"muted\": true}")
+                        .with(httpBasic("soc-demo", "wrong-password"))
+        ).andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testMuteBeacon_withoutCredentials_shouldReturnUnauthorized() throws Exception {
+        // Act & Assert
+        mockMvc.perform(
+                post("/api/beacon/mute")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"muted\": true}")
+        ).andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
### What was done?

*   Updated `SecurityConfig.java` to implement HTTP Basic authentication for all API endpoints under `/api/**`.
*   Disabled CSRF protection, as the backend serves a stateless API.
*   Defined a single in-memory user (`soc-demo` / `demo123!`) for demo and development purposes, with the password stored securely using a `BCryptPasswordEncoder`.
*   Refactored `BeaconControllerTest` to remove mock security context (`@WithMockUser`) and instead test the real authentication flow using `httpBasic()`. Added tests for success (204), wrong credentials (401), and no credentials (401).

### Why was it done?

This PR fulfills the requirements of User Story **T2.5.1**, which establishes the foundational security layer for the backend API. It secures all data endpoints and provides a clear, stateless authentication mechanism for API clients (like the frontend or IoT devices) as defined in the acceptance criteria.

### How to test it?

1.  **Automated Tests:**
    *   Run the tests in `BeaconControllerTest.java`. All three tests (`withCorrectCredentials`, `withWrongCredentials`, `withoutCredentials`) must pass, confirming the security rules are correctly enforced.

2.  **Manual API Testing (using Postman, curl, etc.):**
    *   **Scenario 1 (No Credentials):** Call `GET /api/risk` without providing an `Authorization` header.
        *   **Expected Result:** `401 Unauthorized`.
    *   **Scenario 2 (Wrong Credentials):** Call `GET /api/risk` using Basic Auth with incorrect credentials (e.g., `user: "soc-demo"`, `password: "wrong-password"`).
        *   **Expected Result:** `401 Unauthorized`.
    *   **Scenario 3 (Correct Credentials):** Call `GET /api/risk` using Basic Auth with the correct credentials (`user: "soc-demo"`, `password: "demo123!"`).
        *   **Expected Result:** `200 OK` and a valid JSON response body.