### PR TITLE
T6.2.3 – Configure CORS on the backend for the Vercel domain &&  T3.2.2 – DTO and REST endpoint

### DIFF
--- a/src/main/java/com/threatbeacon/backend/config/CorsConfig.java
+++ b/src/main/java/com/threatbeacon/backend/config/CorsConfig.java
@@ -1,0 +1,48 @@
+package com.threatbeacon.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    private static final String FRONTEND_ORIGIN =
+            "https://threatbeacon-frontend.vercel.app";
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+
+        CorsConfiguration configuration = new CorsConfiguration();
+
+        configuration.setAllowedOrigins(List.of(FRONTEND_ORIGIN));
+
+        configuration.setAllowedMethods(List.of(
+                "GET",
+                "POST",
+                "OPTIONS"
+        ));
+
+        configuration.setAllowedHeaders(List.of(
+                "Authorization",
+                "Content-Type"
+        ));
+
+        configuration.setExposedHeaders(List.of(
+                "Authorization"
+        ));
+
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source =
+                new UrlBasedCorsConfigurationSource();
+
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/threatbeacon/backend/config/SecurityConfig.java
+++ b/src/main/java/com/threatbeacon/backend/config/SecurityConfig.java
@@ -19,13 +19,16 @@ public class SecurityConfig {
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
+        http //(I only changed this block, up to before the return)
+                .cors(withDefaults()) // Enable CORS configuration
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .httpBasic(withDefaults());
+
         return http.build();
     }
 

--- a/src/main/java/com/threatbeacon/backend/incident/IncidentController.java
+++ b/src/main/java/com/threatbeacon/backend/incident/IncidentController.java
@@ -1,0 +1,26 @@
+package com.threatbeacon.backend.incident;
+
+
+import com.threatbeacon.backend.ai.IncidentInsightService;
+import com.threatbeacon.backend.api.dto.IncidentInsightDto;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/incidents")
+public class IncidentController {
+
+    private final IncidentInsightService insightService;
+
+    public IncidentController(IncidentInsightService insightService) {
+        this.insightService = insightService;
+    }
+
+    @GetMapping("/{id}/insights")
+    public IncidentInsightDto getIncidentInsight(@PathVariable Long id) {
+        return insightService.generateInsight(id);
+    }
+}
+


### PR DESCRIPTION
Purpose

These tasks ensure that the backend can safely expose AI-generated incident insights through a REST API and that the deployed frontend can communicate with the backend without being blocked by browser security policies.

Together, they enable a complete, secure, and deployable end-to-end demo.

How it works
T3.2.2 – DTO and REST Endpoint

A new DTO (IncidentInsightDto) is introduced to define a clear and stable contract between the backend and frontend.
The REST endpoint GET /api/incidents/{id}/insights allows clients to request an AI-generated insight for a specific incident.

When the endpoint is called:

The controller delegates the logic to IncidentInsightService.generateInsight(id).

The service generates the insight using OpenAI.

If the OpenAI service is unavailable, a fallback text is returned.

The response is serialized as JSON using IncidentInsightDto.

The endpoint is protected with Basic Authentication, ensuring that only authorized clients can access incident insights.

T6.2.3 – CORS Configuration for Vercel

CORS (Cross-Origin Resource Sharing) is configured in the Spring Boot backend to explicitly allow requests from the deployed Vercel frontend.

The configuration:

Allows only the specific frontend domain (e.g. https://threatbeacon-frontend.vercel.app)

Enables only the HTTP methods required by the frontend (GET, POST)

Allows only necessary headers (Authorization, Content-Type)

This ensures that:

Browser requests from the Vercel frontend are not blocked by CORS

The backend remains protected from unauthorized cross-origin access

Utility and value

Enables secure exposure of AI-generated insights through a REST API

Guarantees consistent JSON responses for frontend consumption

Prevents frontend-backend integration issues in production

Avoids insecure CORS configurations such as allowing all origins (*)

Allows the full demo to run using deployed services (Vercel + Railway) without local workarounds